### PR TITLE
don't set a backgroundColour on drag

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="../src/react-resizable-textarea.css" />
 </head>
 <body>
-    <div id="maincontainer"></div>
+    <div id="maincontainer" style='padding: 20px;'></div>
     <script type="text/javascript" src="../bundle.js" ></script>
 </body>
 </html>

--- a/src/react-resizable-textarea.js
+++ b/src/react-resizable-textarea.js
@@ -54,9 +54,6 @@ class ResizableTextArea extends Component {
         document.addEventListener('mousemove', this._onMouseMove);
         document.addEventListener('mouseup', this._onDisableDrag);
 
-        this._prevTextAreaStyleBackgroundColor = this._textArea.style.backgroundColor;
-        this._textArea.style.backgroundColor = 'transparent';
-
         this._lastY = e.clientY;
         this._lastX = e.clientX;
         this._textAreaHeight = this._textArea.offsetHeight;
@@ -69,7 +66,6 @@ class ResizableTextArea extends Component {
     _onDisableDrag() {
         this._removeEventListeners();
 
-        this._textArea.style.backgroundColor = this._prevTextAreaStyleBackgroundColor;
         // remove selection, which can be a site effect when hovering over the text
         window.getSelection().removeAllRanges();
     }
@@ -127,7 +123,10 @@ class ResizableTextArea extends Component {
         const draggerClassNames = `resizable-textarea-dragger direction-${this.props.directions}`;
 
         return (
-            React.createElement('div', { className: 'resizable-textarea-container', ref: c => this._container = c },
+            React.createElement('div', {
+                className: 'resizable-textarea-container',
+                ref: c => this._container = c
+            },
                 React.createElement('textarea', props),
                 React.createElement('div', { className: draggerClassNames, ref: d => this._dragger = d })
             ));


### PR DESCRIPTION
Fixes #3 

Tested on Edge 13, IE 11, Chrome 55, Canary 58, FF 51 and Neon 1.0 (all Windows 10)