### PR TITLE
Update to react 15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-resizable-textarea",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "./dist/react-resizable-textarea.min.js",
   "devDependencies": {
@@ -20,10 +20,11 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-webpack": "^1.8.0",
     "phantomjs": "^2.1.7",
-    "react": "^15.3.2",
-    "react-addons-test-utils": "^15.3.2",
-    "react-dom": "^15.3.2",
-    "react-testutils-additions": "^15.1.0",
+    "prop-types": "^15.6.0",
+    "react": "^15.6.2",
+    "react-addons-test-utils": "^15.6.2",
+    "react-dom": "^15.6.2",
+    "react-testutils-additions": "^15.3.0",
     "webpack": "^1.13.3",
     "webpack-dev-server": "^1.16.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-resizable-textarea",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "",
   "main": "./dist/react-resizable-textarea.min.js",
   "devDependencies": {
@@ -8,6 +8,7 @@
     "babel-loader": "^6.2.7",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
+    "create-react-class": "^15.6.2",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-loader": "^1.6.1",

--- a/src/react-resizable-textarea.js
+++ b/src/react-resizable-textarea.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class ResizableTextArea extends Component {
     constructor(props) {


### PR DESCRIPTION
React.PropTypes are depricated in react 16
This PR makes it easier to move to latest version of react later on